### PR TITLE
Fix: Design share URL now generates when court component colors are c…

### DIFF
--- a/src/hooks/useDesignUrlState.ts
+++ b/src/hooks/useDesignUrlState.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { CourtType, ElementType, CourtOverlays } from '../types/court';
+import { getDefaultElementColors } from '../utils/courtHelpers';
 
 interface UseDesignUrlStateProps {
   courtDesign: any; // From useCourtDesign hook
@@ -39,18 +40,29 @@ export const useDesignUrlState = ({ courtDesign, selectedCourt }: UseDesignUrlSt
       courtDesign.resetState();
     }    
     courtDesign.updateState({ selectedCourt });
-  }, [selectedCourt, searchParams.get('design')]); // Only depend on the actual design param value// Update URL when significant state changes occur (for sharing)
+  }, [selectedCourt, searchParams.get('design')]); // Only depend on the actual design param value  // Update URL when significant state changes occur (for sharing)
   useEffect(() => {
     // Only update URL if there's actual design data beyond defaults
     const designSummary = courtDesign.getDesignSummary();
+    const defaultColors = getDefaultElementColors();
+    
     const hasCustomizations = Object.entries(designSummary).some(([courtType, courtData]) => {
       if (courtType === 'overlays') {
         return Object.values(courtData as CourtOverlays).some(Boolean);
       }
       if (typeof courtData === 'object' && courtData !== null && 'colors' in courtData) {
         const courtInfo = courtData as any;
-        return Object.keys(courtInfo.colors).length > 1 || // More than just background
-               !courtInfo.showAccessories; // Accessories turned off
+        
+        // Check if accessories are turned off (customization)
+        const accessoriesChanged = !courtInfo.showAccessories;
+        
+        // Check if any color differs from its default value
+        const colorsChanged = Object.entries(courtInfo.colors).some(([element, color]) => {
+          const defaultColor = defaultColors[element];
+          return defaultColor && color !== defaultColor;
+        });
+        
+        return accessoriesChanged || colorsChanged;
       }
       return false;
     });

--- a/src/hooks/useDesignUrlState.ts
+++ b/src/hooks/useDesignUrlState.ts
@@ -59,7 +59,7 @@ export const useDesignUrlState = ({ courtDesign, selectedCourt }: UseDesignUrlSt
         // Check if any color differs from its default value
         const colorsChanged = Object.entries(courtInfo.colors).some(([element, color]) => {
           const defaultColor = defaultColors[element];
-          return defaultColor && color !== defaultColor;
+          return defaultColor !== undefined && color !== defaultColor;
         });
         
         return accessoriesChanged || colorsChanged;


### PR DESCRIPTION
…hanged

- Fixed logic in useDesignUrlState that was only detecting customizations when multiple colors were set or accessories were disabled
- Now properly compares each color against default values to detect any color changes
- Added import for getDefaultElementColors to enable proper comparison
- URL will now update whenever any court element color is changed from its default value